### PR TITLE
fix: 並行レビューで検出された品質問題を6件修正

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -272,20 +272,20 @@ program
       buildFullGraph(db!, existingPaths);
       const elapsed = Date.now() - startMs;
       console.log(`グラフ構築完了 (${elapsed}ms)`);
+      try {
+        const { nodeCount } = db!
+          .prepare("SELECT COUNT(*) as nodeCount FROM nodes")
+          .get() as { nodeCount: number };
+        const { edgeCount } = db!
+          .prepare("SELECT COUNT(*) as edgeCount FROM edges")
+          .get() as { edgeCount: number };
+        console.log(`  ${nodeCount} nodes, ${edgeCount} edges`);
+      } catch {
+        // 統計取得の失敗はグラフ構築の成否に影響しない
+      }
     } catch (err) {
       console.error("グラフ構築に失敗しました:", err instanceof Error ? err.message : err);
       process.exit(1);
-    }
-    try {
-      const { nodeCount } = db!
-        .prepare("SELECT COUNT(*) as nodeCount FROM nodes")
-        .get() as { nodeCount: number };
-      const { edgeCount } = db!
-        .prepare("SELECT COUNT(*) as edgeCount FROM edges")
-        .get() as { edgeCount: number };
-      console.log(`  ${nodeCount} nodes, ${edgeCount} edges`);
-    } catch {
-      // 統計取得の失敗はグラフ構築の成否に影響しない
     } finally {
       db?.close();
     }
@@ -325,8 +325,10 @@ program
       const result = updateFile(db!, resolvedFile);
       if (result === "skipped") {
         console.log(`スキップ（変更なし）: ${file}`);
+      } else if (result === "deleted") {
+        console.log(`削除済みノードをクリア: ${file}`);
       } else {
-        console.log(`更新完了: ${file}`);
+        console.log(`更新完了: ${file} (TYPED_BY/IMPLEMENTS/EXTENDS/HAS_TEST エッジは次回 build で復元されます)`);
       }
     } catch (err) {
       console.error("更新に失敗しました:", err instanceof Error ? err.message : err);

--- a/packages/core/src/analyzer.ts
+++ b/packages/core/src/analyzer.ts
@@ -102,7 +102,7 @@ export function analyzeProject(tsconfigPath: string): AnalysisResult {
   // HAS_TEST エッジ: テストファイルが import する実装ファイルに紐付け
   for (const sf of project.getSourceFiles()) {
     const filePath = sf.getFilePath();
-    if (!isTestFile(filePath)) continue;
+    if (!isTestFile(filePath) || filePath.includes("node_modules")) continue;
     for (const decl of sf.getImportDeclarations()) {
       const resolved = decl.getModuleSpecifierSourceFile();
       if (resolved && !isTestFile(resolved.getFilePath()) && !resolved.getFilePath().includes("node_modules")) {

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -66,14 +66,14 @@ function getStoredHash(db: Db, file: string): string | undefined {
   return row?.hash;
 }
 
-export function updateFile(db: Db, filePath: string): "skipped" | "updated" {
+export function updateFile(db: Db, filePath: string): "skipped" | "updated" | "deleted" {
   if (!existsSync(filePath)) {
     const stmts = getUpdateStmts(db);
     db.transaction(() => {
       stmts.deleteNodes.run(filePath);
       stmts.deleteHash.run(filePath);
     })();
-    return "skipped";
+    return "deleted";
   }
 
   const content = readFileSync(filePath, "utf-8");

--- a/packages/core/tests/db.test.ts
+++ b/packages/core/tests/db.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { openDb } from "../src/db.js";
 import { rmSync, existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 
-const TEST_DB = `/tmp/ts-review-graph-test-${Date.now()}.db`;
+let TEST_DB: string;
+
+beforeEach(() => {
+  TEST_DB = `/tmp/ts-review-graph-test-${randomUUID()}.db`;
+});
 
 afterEach(() => {
   for (const ext of ["", "-wal", "-shm"]) {
@@ -14,41 +19,50 @@ afterEach(() => {
 describe("openDb", () => {
   it("テーブルが存在する", () => {
     const db = openDb(TEST_DB);
-    const tables = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-      .all()
-      .map((r: any) => r.name);
-    expect(tables).toContain("nodes");
-    expect(tables).toContain("edges");
-    expect(tables).toContain("file_hashes");
-    db.close();
+    try {
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+        .all()
+        .map((r: any) => r.name);
+      expect(tables).toContain("nodes");
+      expect(tables).toContain("edges");
+      expect(tables).toContain("file_hashes");
+    } finally {
+      db.close();
+    }
   });
 
   it("nodes に INSERT → edges の CASCADE DELETE が機能する", () => {
     const db = openDb(TEST_DB);
-    db.prepare(
-      "INSERT INTO nodes (id, kind, name, file, line, type_refs) VALUES (?,?,?,?,?,?)"
-    ).run("n1", "function", "foo", "a.ts", 1, "[]");
-    db.prepare(
-      "INSERT INTO nodes (id, kind, name, file, line, type_refs) VALUES (?,?,?,?,?,?)"
-    ).run("n2", "function", "bar", "b.ts", 1, "[]");
-    db.prepare(
-      "INSERT INTO edges (source_id, target_id, kind) VALUES (?,?,?)"
-    ).run("n1", "n2", "CALLS");
+    try {
+      db.prepare(
+        "INSERT INTO nodes (id, kind, name, file, line, type_refs) VALUES (?,?,?,?,?,?)"
+      ).run("n1", "function", "foo", "a.ts", 1, "[]");
+      db.prepare(
+        "INSERT INTO nodes (id, kind, name, file, line, type_refs) VALUES (?,?,?,?,?,?)"
+      ).run("n2", "function", "bar", "b.ts", 1, "[]");
+      db.prepare(
+        "INSERT INTO edges (source_id, target_id, kind) VALUES (?,?,?)"
+      ).run("n1", "n2", "CALLS");
 
-    db.prepare("DELETE FROM nodes WHERE id = ?").run("n1");
+      db.prepare("DELETE FROM nodes WHERE id = ?").run("n1");
 
-    const edge = db
-      .prepare("SELECT * FROM edges WHERE source_id = ?")
-      .get("n1");
-    expect(edge).toBeUndefined();
-    db.close();
+      const edge = db
+        .prepare("SELECT * FROM edges WHERE source_id = ?")
+        .get("n1");
+      expect(edge).toBeUndefined();
+    } finally {
+      db.close();
+    }
   });
 
   it("WAL モードが有効", () => {
     const db = openDb(TEST_DB);
-    const row = db.prepare("PRAGMA journal_mode").get() as any;
-    expect(row.journal_mode).toBe("wal");
-    db.close();
+    try {
+      const row = db.prepare("PRAGMA journal_mode").get() as any;
+      expect(row.journal_mode).toBe("wal");
+    } finally {
+      db.close();
+    }
   });
 });

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -61,7 +61,7 @@ describe("updateFile", () => {
     expect(node).toBeUndefined(); // baz ノードが消えている
   });
 
-  it("ファイルが存在しない場合はノードとハッシュを削除して 'skipped' を返す", () => {
+  it("ファイルが存在しない場合はノードとハッシュを削除して 'deleted' を返す", () => {
     const filePath = path.join(tmpDir, "d.ts");
     writeFileSync(filePath, "export function gone() {}");
     updateFile(db, filePath);
@@ -70,7 +70,7 @@ describe("updateFile", () => {
     rmSync(filePath);
     const result = updateFile(db, filePath);
 
-    expect(result).toBe("skipped");
+    expect(result).toBe("deleted");
     const nodes = db.prepare("SELECT * FROM nodes WHERE file = ?").all(filePath);
     expect(nodes.length).toBe(0);
     const hash = db.prepare("SELECT * FROM file_hashes WHERE file = ?").get(filePath);

--- a/packages/mcp-server/src/tools/get-minimal-context.ts
+++ b/packages/mcp-server/src/tools/get-minimal-context.ts
@@ -192,11 +192,16 @@ export function getMinimalContext(
 
     lines.push(``, `SKIP: ${Math.max(0, totalFiles - reverseFiles.size - forwardFiles.size)} other files — not in blast radius`);
   } else {
-    const totalReverse = reverseFiles.size;
+    const displayedReverse: [string, string][] = [];
+    for (const [file, reason] of reverseFiles) {
+      if (changedSet.has(file)) continue;
+      displayedReverse.push([file, reason]);
+    }
+    const totalReverse = displayedReverse.length;
     lines.push(`READ THESE FILES ONLY (${totalReverse} files, mode=${mode}, depth=${maxDepth}):`);
     let i = 1;
     let shown = 0;
-    for (const [file, reason] of reverseFiles) {
+    for (const [file, reason] of displayedReverse) {
       if (shown >= MAX_CONTEXT_FILES) break;
       lines.push(`  ${i++}. ${file}  [${reason.replace(/[\r\n]/g, "")}]`);
       shown++;
@@ -204,7 +209,7 @@ export function getMinimalContext(
     if (totalReverse > MAX_CONTEXT_FILES) {
       lines.push(`  ... (${totalReverse - MAX_CONTEXT_FILES} more — narrow changed_files or use review mode)`);
     }
-    lines.push(``, `SKIP: ${Math.max(0, totalFiles - totalReverse)} other files — not in blast radius`);
+    lines.push(``, `SKIP: ${Math.max(0, totalFiles - reverseFiles.size)} other files — not in blast radius`);
   }
 
   return { content: [{ type: "text", text: lines.join("\n") }] };


### PR DESCRIPTION
## Summary

- **updater**: ファイル削除時の戻り値を `"skipped"` → `"deleted"` に変更し、ハッシュ変更なし (`"skipped"`) との意味的混同を解消
- **analyzer**: HAS_TEST ループで `node_modules` 内テストファイルをフィルタ（メインループとの非対称チェック解消）
- **get-minimal-context**: `review`/`debug` モードで変更ファイル自身を「READ THESE FILES ONLY」リストから除外（`implement` モードとの一貫性確保、SKIP カウントは `reverseFiles.size` ベースを維持）
- **cli/build**: `buildFullGraph` 失敗時も `finally { db?.close() }` が実行されるよう統計クエリを内側 `try` ブロックに移動
- **cli/update**: `"deleted"` 結果のメッセージ追加、更新完了時に TYPED_BY 等エッジ欠落の注意を表示
- **db.test**: `Date.now()` → `randomUUID()` + `beforeEach` でテスト並列実行時の DB パス衝突を解消、各テストを `try/finally` で `db.close()` を保証

## Test plan

- [x] `pnpm test` — 86/86 通過 (packages/core: 26件, packages/mcp-server: 60件)
- [x] 5名の専門レビュアー × 3ラウンドの並行レビューサイクルで全員 LGTM
- [x] 偽陽性 8件を FP レジストリで管理・棄却済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)