### PR TITLE
fix: 並行レビューサイクルで検出された品質問題を修正

### DIFF
--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -147,6 +147,24 @@ export function updateFile(db: Db, filePath: string): "skipped" | "updated" | "d
       });
     }
 
+    // 変数ノード（エクスポートされたもののみ）
+    for (const vs of sf.getVariableStatements()) {
+      if (!vs.isExported()) continue;
+      for (const decl of vs.getDeclarations()) {
+        const name = decl.getName();
+        if (!name) continue;
+        insertNode.run({
+          id: `${filePath}::${name}`,
+          kind: "variable",
+          name,
+          file: filePath,
+          line: decl.getStartLineNumber(),
+          signature: null,
+          typeRefs: "[]",
+        });
+      }
+    }
+
     // IMPORTS_FROM エッジを復元（相対インポートのみ）
     // Note: TYPED_BY/IMPLEMENTS/EXTENDS/HAS_TEST はクロスファイル解決が必要なため
     // 次回フル build 時に復元される
@@ -156,12 +174,14 @@ export function updateFile(db: Db, filePath: string): "skipped" | "updated" | "d
       if (!moduleSpec.startsWith(".")) continue;
 
       const base = resolvePath(dirname(filePath), moduleSpec);
+      // ESM imports use .js extension but the file on disk is .ts
+      const tsBase = base.endsWith(".js") ? base.slice(0, -3) : base;
       const candidates = [
         base,
-        `${base}.ts`,
-        `${base}.tsx`,
-        `${base}/index.ts`,
-        `${base}/index.tsx`,
+        `${tsBase}.ts`,
+        `${tsBase}.tsx`,
+        `${tsBase}/index.ts`,
+        `${tsBase}/index.tsx`,
       ];
 
       for (const candidate of candidates) {
@@ -188,6 +208,7 @@ export function updateFile(db: Db, filePath: string): "skipped" | "updated" | "d
   });
 
   run();
+  project.removeSourceFile(sf);
   return "updated";
 }
 

--- a/packages/core/tests/analyzer.test.ts
+++ b/packages/core/tests/analyzer.test.ts
@@ -25,18 +25,30 @@ describe("analyzeProject", () => {
     const { edges } = analyzeProject(FIXTURE);
     const importEdges = edges.filter((e) => e.kind === "IMPORTS_FROM");
     expect(importEdges.length).toBeGreaterThan(0);
+    // b.ts が a.ts を import するエッジが存在する
+    expect(importEdges.some((e) => e.sourceId.includes("b.ts") && e.targetId.includes("a.ts"))).toBe(true);
   });
 
   it("IMPLEMENTS エッジを生成する", () => {
     const { edges } = analyzeProject(FIXTURE);
     const implementsEdges = edges.filter((e) => e.kind === "IMPLEMENTS");
     expect(implementsEdges.length).toBeGreaterThan(0);
+    // b.ts::Dog が a.ts::Animal を implements するエッジが存在する
+    expect(implementsEdges.some(
+      (e) => e.sourceId.includes("b.ts") && e.sourceId.includes("Dog") &&
+             e.targetId.includes("a.ts") && e.targetId.includes("Animal")
+    )).toBe(true);
   });
 
   it("TYPED_BY エッジを生成する（引数型参照）", () => {
     const { edges } = analyzeProject(FIXTURE);
     const typedByEdges = edges.filter((e) => e.kind === "TYPED_BY");
     expect(typedByEdges.length).toBeGreaterThan(0);
+    // b.ts::introduce が a.ts::Animal に型参照するエッジが存在する（b.ts::Dog と区別して確認）
+    expect(typedByEdges.some(
+      (e) => e.sourceId.includes("b.ts") && e.sourceId.includes("introduce") &&
+             e.targetId.includes("a.ts") && e.targetId.includes("Animal")
+    )).toBe(true);
   });
 
   it("HAS_TEST エッジを生成する", () => {

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -77,6 +77,34 @@ describe("updateFile", () => {
     expect(hash).toBeUndefined();
   });
 
+  it("エクスポート変数ノードが挿入される", () => {
+    const filePath = path.join(tmpDir, "vars.ts");
+    writeFileSync(filePath, "export const myConst = 42;");
+
+    updateFile(db, filePath);
+
+    const node = db.prepare("SELECT * FROM nodes WHERE id = ?").get(`${filePath}::myConst`);
+    expect(node).toBeTruthy();
+    expect((node as any).kind).toBe("variable");
+  });
+
+  it("import 先ノードが DB に存在する場合に IMPORTS_FROM エッジが復元される", () => {
+    const libPath = path.join(tmpDir, "lib.ts");
+    const appPath = path.join(tmpDir, "app.ts");
+    writeFileSync(libPath, "export function libFn() {}");
+    writeFileSync(appPath, `import { libFn } from "./lib.js";\nexport function useLib() { return libFn(); }`);
+
+    // まず lib.ts を DB に登録して lib.ts::__file__ ノードを作成
+    updateFile(db, libPath);
+    // 次に app.ts を更新（lib.ts::__file__ が DB に存在するので IMPORTS_FROM エッジが生成される）
+    updateFile(db, appPath);
+
+    const edge = db
+      .prepare("SELECT * FROM edges WHERE source_id = ? AND target_id = ? AND kind = 'IMPORTS_FROM'")
+      .get(`${appPath}::__file__`, `${libPath}::__file__`);
+    expect(edge).toBeTruthy();
+  });
+
   it("削除後に同名ファイルが同じ内容で再作成されたらグラフを更新する", () => {
     const filePath = path.join(tmpDir, "e.ts");
     const content = "export function revived() {}";

--- a/packages/mcp-server/src/tools/build-graph.ts
+++ b/packages/mcp-server/src/tools/build-graph.ts
@@ -52,6 +52,7 @@ export function buildGraph(args: Record<string, unknown>): ToolResult {
     Array.isArray(rawTsconfigs) && rawTsconfigs.every((x) => typeof x === "string")
       ? (rawTsconfigs as string[])
       : undefined;
+
   const tsconfigPaths = loadTsconfigPaths(cwd, argTsconfigs);
 
   const missing = tsconfigPaths.filter((p) => !existsSync(p));

--- a/packages/mcp-server/src/tools/get-type-usages.ts
+++ b/packages/mcp-server/src/tools/get-type-usages.ts
@@ -35,7 +35,7 @@ export function getTypeUsages(
   const escaped = typeName.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
   let rows: Array<{ file: string; name: string; kind: string }>;
   try {
-    rows = getTypeUsagesStmt(db).all(`%${escaped}%`) as typeof rows;
+    rows = getTypeUsagesStmt(db).all(`%::${escaped}%`) as typeof rows;
   } catch (err) {
     return {
       content: [{ type: "text", text: `型使用箇所の検索に失敗しました: ${err instanceof Error ? err.message : String(err)}` }],

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -288,7 +288,7 @@ describe("get_type_usages", () => {
     const typedFile = path.join(TEST_PROJECT_ROOT, "typed.ts");
     db.prepare(
       "INSERT OR REPLACE INTO nodes (id, kind, name, file, line, type_refs) VALUES (?,?,?,?,?,?)"
-    ).run("typed::__file__", "file", "typed.ts", typedFile, 1, '["MonitorConfig","string"]');
+    ).run("typed::__file__", "file", "typed.ts", typedFile, 1, '["types.ts::MonitorConfig","string"]');
 
     const result = registerTools(db, "get_type_usages", { type_name: "MonitorConfig" });
     expect(result.isError).toBeFalsy();
@@ -313,7 +313,7 @@ describe("get_type_usages", () => {
     const underscoreFile = path.join(TEST_PROJECT_ROOT, "underscore_typed.ts");
     db.prepare(
       "INSERT OR REPLACE INTO nodes (id, kind, name, file, line, type_refs) VALUES (?,?,?,?,?,?)"
-    ).run("underscore::__file__", "file", "underscore_typed.ts", underscoreFile, 1, '["My_Type"]');
+    ).run("underscore::__file__", "file", "underscore_typed.ts", underscoreFile, 1, '["types.ts::My_Type"]');
     const result = registerTools(db, "get_type_usages", { type_name: "My_Type" });
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toContain("My_Type");
@@ -686,7 +686,7 @@ describe("get_type_usages MAX_TYPE_RESULTS 打ち切り", () => {
     );
     for (let i = 0; i < 501; i++) {
       const f = path.join(TEST_PROJECT_ROOT, `type_test_${i}.ts`);
-      insert.run(`type_test_${i}::__file__`, "file", `type_test_${i}.ts`, f, 1, '["MyUniqueType"]');
+      insert.run(`type_test_${i}::__file__`, "file", `type_test_${i}.ts`, f, 1, '["types.ts::MyUniqueType"]');
     }
 
     const result = registerTools(db, "get_type_usages", { type_name: "MyUniqueType" });


### PR DESCRIPTION
## Summary

- **`updater.ts` ESM `.js`→`.ts` 変換**: `import './foo.js'` 形式の ESM インポートで `IMPORTS_FROM` エッジが生成されない問題を修正
- **`updater.ts` variable ノード欠落**: `analyzeProject` が生成するエクスポート変数ノードを `updateFile` でも挿入するよう修正（増分更新後にノードが消える問題）
- **`updater.ts` メモリ抑制**: `Project.removeSourceFile()` 追加で ts-morph の AST リソースを早期解放
- **`get-type-usages.ts` LIKE パターン修正**: `%TypeName%` → `%::TypeName%` に変更し、ファイルパス部分（`src/foo.ts` 等）への誤マッチを防止
- テスト品質向上: 具体的な `sourceId`/`targetId` アサーション、variable ノードと IMPORTS_FROM 復元のカバレッジ追加、`type_refs` テストデータを本番 nodeId 形式に統一

## Test plan

- [x] `pnpm test` 全96テスト通過（core: 28、mcp-server: 68）
- [x] 4ラウンドの並行専門家レビュー（Security / Core Logic / Tests / Domain / Fresh Eyes）で LGTM 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)